### PR TITLE
Add continued fraction evaluator

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -14578,3 +14578,8 @@ add_newdoc("_stirling2_inexact",
     r"""
     Internal function, do not use.
     """)
+
+add_newdoc("_iv_ratio",
+    """
+    Internal function, use `ellip_harm` instead.
+    """)

--- a/scipy/special/_iv_ratio.h
+++ b/scipy/special/_iv_ratio.h
@@ -1,0 +1,26 @@
+// Numerically stable computation of iv(v+1, x) / iv(v, x)
+
+#pragma once
+
+#include "special/tools.h"
+
+class IvRatioCFGenerator {
+  /* This is the continued fraction for (1 + sqrt(1 + 4x))/2. Replace the
+   * operator with something which generates the coefficients for Perron's
+   * continued fraction.
+   */
+
+public:
+  IvRatioCFGenerator(double v, double x) : v_(v), x_(x) {}
+
+  std::pair<double, double> operator()() { return {1.0, v_ * x_}; }
+
+private:
+  double v_, x_;
+};
+
+inline double iv_ratio(double v, double x) {
+  auto generator = IvRatioCFGenerator(v, x);
+  return special::detail::continued_fraction_eval(
+      generator, 1.0, std::numeric_limits<double>::epsilon(), 500, "iv_ratio");
+}

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -824,6 +824,11 @@
             "iv": "dd->d"
         }
     },
+    "_iv_ratio": {
+        "_iv_ratio.h++": {
+            "iv_ratio": "dd->d"
+        }
+    },
     "ive": {
         "amos_wrappers.h": {
             "cbesi_wrap_e": "dD->D",

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -350,7 +350,8 @@ special_sources = [
   'special/trig.h',
   'special/zlog1.h',
   'special/loggamma.h',
-  'special/digamma.h'
+  'special/digamma.h',
+  'special/tools.h'
 ]
 
 special_cephes_sources = [

--- a/scipy/special/special/tools.h
+++ b/scipy/special/special/tools.h
@@ -1,0 +1,89 @@
+/* Building blocks for implementing special functions */
+
+#pragma once
+
+#include "config.h"
+#include "error.h"
+
+namespace special {
+namespace detail {
+
+    namespace maybe_complex_numeric_limits {
+        // Handle numeric limits when type may be complex.
+        template <typename T>
+        SPECFUN_HOST_DEVICE inline std::enable_if_t<std::is_floating_point_v<T>, T> quiet_NaN() {
+            return std::numeric_limits<T>::quiet_NaN();
+        }
+
+        template <typename T>
+        SPECFUN_HOST_DEVICE inline std::enable_if_t<!std::is_floating_point_v<T>, T> quiet_NaN() {
+            using V = typename T::value_type;
+            return {std::numeric_limits<V>::quiet_NaN(), std::numeric_limits<V>::quiet_NaN()};
+        }
+
+        template <typename T>
+        SPECFUN_HOST_DEVICE inline std::enable_if_t<std::is_floating_point_v<T>, T> min() {
+            return std::numeric_limits<T>::min();
+        }
+
+        template <typename T>
+        SPECFUN_HOST_DEVICE inline std::enable_if_t<!std::is_floating_point_v<T>, T> min() {
+            using V = typename T::value_type;
+            return std::numeric_limits<V>::min();
+        }
+
+    } // namespace maybe_complex_numeric_limits
+
+    template <typename Generator, typename T>
+    SPECFUN_HOST_DEVICE T continued_fraction_eval(Generator &g, T init_val, double tol, std::uint64_t max_terms,
+                                                  const char *func_name) {
+        /* Evaluate continued fraction with modified Lentz's algorithm.
+         *
+         * Evaluates the continued fraction b0 + a1 / (b1 + a1 / (b2 + a2 / ( ...
+         *
+         * g : Generator of pairs of values (a1, b1), (a2, b2), (a3, b3), ...
+         *
+         * init_val : Initial value b0
+         *
+         * tol : relative tolerance for stopping criterion.
+         *
+         * max_terms : The maximum number of iterations before giving up and declaring
+         *     non-convergence.
+         *
+         * func_name : The name of the function within SciPy where this call to series_eval
+         *     will ultimately be used. This is needed to pass to set_error in case
+         *     of non-convergence.
+         */
+        std::pair<T, T> v;
+
+        T tiny_value = 16.0 * maybe_complex_numeric_limits::min<T>();
+        T f = (init_val == 0.0) ? tiny_value : init_val;
+
+        double C = f;
+        double D = 0.0;
+        double delta;
+
+        for (uint64_t i = 0; i < max_terms; i++) {
+            v = g();
+            D = v.second + v.first * D;
+            if (D == 0.0) {
+                D = tiny_value;
+            }
+            C = v.second + v.first / C;
+            if (C == 0.0) {
+                C = tiny_value;
+            }
+            D = 1.0 / D;
+            delta = C * D;
+            f *= delta;
+            if (std::abs(delta - 1.0) <= tol) {
+                return f;
+            }
+        }
+        // Exceeded max terms without converging. Return NaN.
+        set_error(func_name, SF_ERROR_NO_RESULT, NULL);
+        return maybe_complex_numeric_limits::quiet_NaN<T>();
+    }
+
+} // namespace detail
+} // namespace special


### PR DESCRIPTION
Hi @fancidev. Here's a PR with the promised continued fraction evaluator. I've added a stub for iv_ratio using a different, simpler, continued fraction. That should give you an idea of how to use the evaluator, but let me know if you have any questions.

From here, you can try out Perron's continued fraction. Once you get it working well, then add some thorough tests. Unfortunately, we can't mix this generator with the `ive` implementation from `AMOS` without writing some annoying and unwanted wrapper code. Hopefully things will work well without that, otherwise this will have to wait until AMOS is translated into C++ (not as far off as you might think, we just did specfun for instance: https://github.com/scipy/scipy/pull/20243).

Unfortunately I don't have time to give more details today, but hopefully this can get you started.